### PR TITLE
State that it's the MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,12 @@ As of 12 February 2024, upon the transfer of the repository ownership to CVS Hea
 
 “Testaro” means “collection of tests” in Esperanto.
 
+
+## License
+
 /*
+  MIT License
+
   © 2021–2024 CVS Health and/or one of its affiliates. All rights reserved.
 
   Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Just thought that you should state the license here, rather than just the text. Easiest would just be to point folks to the License file, but doesn't make sense to just include the text of the license, under the name.