### PR TITLE
correct linkAmb test and its validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testaro",
-  "version": "55.5.12",
+  "version": "55.5.13",
   "description": "Run 1000 web accessibility tests from 11 tools and get a standardized report",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testaro",
-  "version": "55.5.11",
+  "version": "55.5.12",
   "description": "Run 1000 web accessibility tests from 11 tools and get a standardized report",
   "main": "index.js",
   "scripts": {

--- a/testaro/linkAmb.js
+++ b/testaro/linkAmb.js
@@ -40,21 +40,29 @@ const {getLocatorData} = require('../procs/getLocatorData');
 exports.reporter = async (page, withItems) => {
   // Initialize the locators and result.
   const all = await init(100, page, 'a[href]:visible');
-  const linkTexts = new Set();
+  const linksData = [];
   // For each locator:
   for (const loc of all.allLocs) {
     // Get its text.
     const elData = await getLocatorData(loc);
-    // If a previous link has the same text:
     const linkText = elData.excerpt.toLowerCase();
-    if (linkTexts.has(linkText)) {
-      // Add the locator to the array of violators.
-      all.locs.push(loc);
-    }
-    // Otherwise, i.e. if this is the first link with the text:
-    else {
-      // Record its text.
-      linkTexts.add(linkText);
+    // Get its destination.
+    const linkTo = await loc.getAttribute('href');
+    // If the text and destination exist:
+    if (linkText && linkTo) {
+      // If a previous link has the same text but a different destination:
+      if (linksData.some(linkData => linkData.text === linkText && linkData.to !== linkTo)) {
+        // Add the locator to the array of violators.
+        all.locs.push(loc);
+      }
+      // Otherwise, i.e. if no previous link has the same taxt but a different destination:
+      else {
+        // Record its text and destination.
+        linksData.push({
+          text: linkText,
+          to: linkTo
+        });
+      }
     }
   }
   // Populate and return the result.

--- a/testaro/linkAmb.js
+++ b/testaro/linkAmb.js
@@ -1,5 +1,5 @@
 /*
-  © 2023 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2023–2025 CVS Health and/or one of its affiliates. All rights reserved.
 
   MIT License
 

--- a/validation/tests/jobs/linkAmb.json
+++ b/validation/tests/jobs/linkAmb.json
@@ -2,16 +2,25 @@
   "id": "linkAmb",
   "what": "validation of linkAmb test",
   "strict": true,
+  "standard": "only",
+  "observe": false,
+  "device": {
+    "id": "default"
+  },
+  "browserID": "webkit",
+  "creationTimeStamp": "240101T1500",
+  "executionTimeStamp": "240101T1200",
+  "target": {
+    "what": "page with unambiguous and ambiguous links",
+    "url": "file://validation/tests/targets/linkAmb/index.html"
+  },
+  "sources": {
+  },
   "timeLimit": 20,
   "acts": [
     {
-      "type": "launch",
-      "which": "chromium",
-      "url": "file://validation/tests/targets/linkAmb/index.html",
-      "what": "page with unambiguous and ambiguous links"
-    },
-    {
       "type": "test",
+      "launch": {},
       "which": "testaro",
       "withItems": true,
       "stopOnFail": true,
@@ -84,6 +93,7 @@
     },
     {
       "type": "test",
+      "launch": {},
       "which": "testaro",
       "withItems": false,
       "stopOnFail": true,
@@ -124,11 +134,5 @@
         "linkAmb"
       ]
     }
-  ],
-  "sources": {
-  },
-  "standard": "only",
-  "observe": false,
-  "timeStamp": "240101T1500",
-  "creationTimeStamp": "240101T1200"
+  ]
 }

--- a/validation/tests/targets/linkAmb/index.html
+++ b/validation/tests/targets/linkAmb/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-  © 2023 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2023–2025 CVS Health and/or one of its affiliates. All rights reserved.
 
   MIT License
 
@@ -33,9 +33,14 @@
     <main>
       <h1>Page with unambiguous and ambiguous links</h1>
       <p>This is a normal link to <a href="https://en.wikipedia.org">English information</a>.</p>
+      <p>The next two links, too, are unambiguous. Although they have the same name, they also have the same destination.</p>
+      <ul>
+        <li><a id="basqueInfoWP0" href="https://eus.wikipedia.org">Basque information</a></li>
+        <li><a id="basqueInfoWP1" href="https://eus.wikipedia.org">Basque information</a></li>
+      </ul>
       <p>However, the next two links are ambiguous, because their names are the same and yet they have different destinations:</p>
       <ul>
-        <li><a id="basqueInfoWP" href="https://eus.wikipedia.org">Basque information</a></li>
+        <li><a id="basqueInfoWP2" href="https://eus.wikipedia.org">Basque information</a></li>
         <li><a id="basqueInfoICB" href="https://www.eke.eus/en/kultura/basque-country">Basque information</a></li>
       </ul>
     </main>

--- a/validation/validateTest.js
+++ b/validation/validateTest.js
@@ -1,5 +1,5 @@
 /*
-  © 2022–2024 CVS Health and/or one of its affiliates. All rights reserved.
+  © 2022–2025 CVS Health and/or one of its affiliates. All rights reserved.
 
   MIT License
 
@@ -31,7 +31,7 @@
 
 // Module to process files.
 const fs = require('fs').promises;
-// Module to run Testaro jebs.
+// Module to run Testaro jobs.
 const {doJob} = require('../run');
 
 // FUNCTIONS
@@ -42,7 +42,7 @@ exports.validateTest = async testID => {
   const jobFileNames = await fs.readdir(`${__dirname}/tests/jobs`);
   for (const jobFileName of jobFileNames.filter(fileName => fileName === `${testID}.json`)) {
     const jobJSON = await fs.readFile(`${__dirname}/tests/jobs/${jobFileName}`, 'utf8');
-    const report = JSON.parse(jobJSON);
+    let report = JSON.parse(jobJSON);
     // Perform it.
     report = await doJob(report);
     // Report whether the end time was reported.


### PR DESCRIPTION
Make the test accept links that are identical in both name and `href` value. Make validator test for this.

Defects in test validation in general were discovered but not corrected in this pull request. The `timeLimit` property of jobs remains to be treated consistently in future work.