### PR TITLE
Add 5 training Testaro rules (altScheme, captionLoc, datalistRef, secHeading, textSem)

### DIFF
--- a/VALIDATION_README.md
+++ b/VALIDATION_README.md
@@ -1,0 +1,29 @@
+# Validation README
+
+Quick notes to run the Testaro validation tests locally (Windows PowerShell):
+
+1. Install project dependencies
+
+```powershell
+npm install
+```
+
+2. Install Playwright browsers (required)
+
+```powershell
+npx playwright install
+```
+
+3. Run a validation for a specific rule (example: `altScheme`)
+
+```powershell
+npm test altScheme
+```
+
+Notes:
+- If a validator job is stored under `validation/tests/jobProperties/pending`, copy it to `validation/tests/jobProperties/` or run the validator via the provided filenames. `altScheme` was copied already.
+- If a test fails its expectations, read the JSON output printed by the validation harness for `standardResult` and `expectations` to identify missing instances.
+- After making changes to rule implementations in `testaro/`, re-run the specific `npm test <ruleID>` until the validator reports success.
+
+Preparing a PR:
+- Create a branch (example `feature/add-training-rules`), commit your changes, push to remote, and open a PR describing which rules are training vs clean-room.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testaro",
-  "version": "57.4.0",
+  "version": "57.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "testaro",
-      "version": "57.4.0",
+      "version": "57.4.1",
       "license": "MIT",
       "dependencies": {
         "@qualweb/act-rules": "*",

--- a/scripts/dumpAlts.js
+++ b/scripts/dumpAlts.js
@@ -1,0 +1,18 @@
+const { chromium } = require('playwright');
+const path = require('path');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const target = `file://${path.resolve(__dirname, '../validation/tests/targets/altScheme/index.html')}`;
+  console.log('Opening', target);
+  await page.goto(target, { waitUntil: 'domcontentloaded' });
+  const images = await page.$$eval('img', imgs => imgs.map(img => ({
+    id: img.id || null,
+    alt: img.getAttribute('alt'),
+    src: img.getAttribute('src'),
+    href: img.getAttribute('href')
+  })));
+  console.log(JSON.stringify(images, null, 2));
+  await browser.close();
+})();

--- a/testaro/altScheme.js
+++ b/testaro/altScheme.js
@@ -1,0 +1,33 @@
+/*
+  altScheme
+  Identify img elements whose alt attribute is an entire URL or clearly a file name (favicon).
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  // Candidate images: any img with an alt attribute (including empty)
+  const all = await init(100, page, 'img[alt]');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      const alt = (el.getAttribute('alt') || '').trim();
+      if (!alt) return false;
+  // full-string URL (http(s) or file or ftp) — must be the entire alt value
+  if (/^\s*(?:https?:|file:|ftp:)\S+\s*$/i.test(alt)) return true;
+      // favicon or typical file names
+      if (/favicon/i.test(alt)) return true;
+  // common image file extensions that occupy the entire alt or are the base filename
+  if (/^\s*\S+\.(?:png|jpe?g|gif|svg|webp|ico)\s*$/i.test(alt)) return true;
+      // match exact equality with src or href attributes
+      const href = (el.getAttribute('href') || el.getAttribute('src') || '').trim();
+      if (href && alt === href) return true;
+      return false;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element has an alt attribute with a URL as its entire value',
+    'img elements have alt attributes with URLs as their entire values'
+  ];
+  return await report(withItems, all, 'altScheme', whats, 2);
+};

--- a/testaro/captionLoc.js
+++ b/testaro/captionLoc.js
@@ -1,0 +1,23 @@
+/*
+  captionLoc
+  Report caption elements that are not the first child of their table element.
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(100, page, 'caption');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      const parent = el.parentElement;
+      if (!parent || parent.tagName !== 'TABLE') return false;
+      return parent.firstElementChild !== el;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element is not the first child of a table element',
+    'caption elements are not the first children of table elements'
+  ];
+  return await report(withItems, all, 'captionLoc', whats, 3, 'CAPTION');
+};

--- a/testaro/datalistRef.js
+++ b/testaro/datalistRef.js
@@ -1,0 +1,24 @@
+/*
+  datalistRef
+  Report inputs whose list attribute references a missing or ambiguous datalist
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(100, page, 'input[list]');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      const list = el.getAttribute('list');
+      if (!list) return false;
+      const matches = Array.from(document.querySelectorAll('datalist')).filter(d => d.id === list);
+      return matches.length !== 1;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'list attribute of the element references an ambiguous or missing datalist element',
+    'list attributes of elements reference ambiguous or missing datalist elements'
+  ];
+  return await report(withItems, all, 'datalistRef', whats, 3, 'INPUT');
+};

--- a/testaro/secHeading.js
+++ b/testaro/secHeading.js
@@ -1,0 +1,34 @@
+/*
+  secHeading
+  Flag headings that are a lower-numbered heading (e.g., H2 after H3) than the
+  immediately preceding heading within the same sectioning container.
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(200, page, 'h1,h2,h3,h4,h5,h6');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      // find nearest sectioning ancestor
+      let ancestor = el.parentElement;
+      while (ancestor && !['SECTION','ARTICLE','NAV','ASIDE','MAIN','BODY','HTML'].includes(ancestor.tagName)) {
+        ancestor = ancestor.parentElement;
+      }
+      if (!ancestor) return false;
+      const headings = Array.from(ancestor.querySelectorAll('h1,h2,h3,h4,h5,h6'));
+      const idx = headings.indexOf(el);
+      if (idx <= 0) return false;
+      const prev = headings[idx - 1];
+      const curLevel = Number(el.tagName.substring(1));
+      const prevLevel = Number(prev.tagName.substring(1));
+      return curLevel < prevLevel;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element violates the logical level order in its sectioning container',
+    'Heading elements violate the logical level order in their sectioning containers'
+  ];
+  return await report(withItems, all, 'secHeading', whats, 1);
+};

--- a/testaro/textSem.js
+++ b/testaro/textSem.js
@@ -1,0 +1,23 @@
+/*
+  textSem
+  Report semantically vague inline elements: i, b, small
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(100, page, 'i, b, small');
+  for (const loc of all.allLocs) {
+    // Consider only elements with visible text
+    const isBad = await loc.evaluate(el => {
+      const text = (el.textContent || '').trim();
+      return !!text;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element is semantically vague',
+    'Semantically vague elements i, b, and/or small are used'
+  ];
+  return await report(withItems, all, 'textSem', whats, 0);
+};

--- a/tests/testaro.js
+++ b/tests/testaro.js
@@ -56,11 +56,6 @@ const futureEvalRulesCleanRoom = {
 };
 */
 const futureRules = new Set([
-  'altScheme',
-  'captionLoc',
-  'dataListRef',
-  'secHeading',
-  'textSem',
   'adbID',
   'imageLink',
   'legendLoc',
@@ -68,6 +63,11 @@ const futureRules = new Set([
   'phOnly'
 ]);
 const evalRules = {
+  altScheme: 'img elements with alt attributes having URLs as their entire values',
+  captionLoc: 'caption elements that are not first children of table elements',
+  datalistRef: 'elements with ambiguous or missing referenced datalist elements',
+  secHeading: 'headings that violate the logical level order in their sectioning containers',
+  textSem: 'semantically vague elements i, b, and/or small',
   allCaps: 'leaf elements with entirely upper-case text longer than 7 characters',
   allHidden: 'page that is entirely or mostly hidden',
   allSlanted: 'leaf elements with entirely italic or oblique text longer than 39 characters',

--- a/validation/tests/jobProperties/altScheme.json
+++ b/validation/tests/jobProperties/altScheme.json
@@ -1,0 +1,147 @@
+{
+  "rule": "altScheme",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/altScheme/index.html",
+        "what": "page with elements having textual and URL text alternatives"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.2",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "altScheme"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element has an alt attribute with a URL as its entire value"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "IMG"
+        ],
+        [
+          "standardResult.instances.0.id",
+          "=",
+          "mapPNG"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "selector"
+        ],
+        [
+          "standardResult.instances.0.location.spec",
+          "=",
+          "#mapPNG"
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "i",
+          "Blank_map_of_states"
+        ],
+        [
+          "standardResult.instances.1.what",
+          "=",
+          "Element has an alt attribute with a URL as its entire value"
+        ],
+        [
+          "standardResult.instances.1.tagName",
+          "=",
+          "IMG"
+        ],
+        [
+          "standardResult.instances.1.location.spec.height",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "i",
+          "httpforever"
+        ],
+        [
+          "standardResult.instances.2.excerpt",
+          "i",
+          "favicon"
+        ]
+      ],
+      "rules": [
+        "y",
+        "altScheme"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.2",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "altScheme"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "img elements have alt attributes with URLs as their entire values"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          3
+        ]
+      ],
+      "rules": [
+        "y",
+        "altScheme"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/captionLoc.json
+++ b/validation/tests/jobProperties/captionLoc.json
@@ -1,0 +1,132 @@
+{
+  "rule": "captionLoc",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/captionLoc/index.html",
+        "what": "page with standard and nonstandard caption locations"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "captionLoc"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element is not the first child of a table element"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "CAPTION"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.width",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "Office personnel"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "=",
+          "Farm personnel"
+        ]
+      ],
+      "rules": [
+        "y",
+        "captionLoc"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "captionLoc"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "caption elements are not the first children of table elements"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "CAPTION"
+        ]
+      ],
+      "rules": [
+        "y",
+        "captionLoc"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/datalistRef.json
+++ b/validation/tests/jobProperties/datalistRef.json
@@ -1,0 +1,122 @@
+{
+  "rule": "datalistRef",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/datalistRef/index.html",
+        "what": "page with correct and erroneous datalist references"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.2",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "datalistRef"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "list attribute of the element references an ambiguous or missing datalist element"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "INPUT"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.height",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "i",
+          "material"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "i",
+          "city"
+        ]
+      ],
+      "rules": [
+        "y",
+        "datalistRef"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "datalistRef"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "list attributes of elements reference ambiguous or missing datalist elements"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          2
+        ]
+      ],
+      "rules": [
+        "y",
+        "datalistRef"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/secHeading.json
+++ b/validation/tests/jobProperties/secHeading.json
@@ -1,0 +1,137 @@
+{
+  "rule": "secHeading",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/secHeading/index.html",
+        "what": "page with sections having logical and illogical heading sequences"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "secHeading"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element violates the logical level order in its sectioning container"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "H2"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.y",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "This heading is illogical"
+        ],
+        [
+          "standardResult.instances.1.tagName",
+          "=",
+          "H1"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "=",
+          "This heading is fundamentally illogical"
+        ],
+        [
+          "standardResult.instances.2.tagName",
+          "=",
+          "H2"
+        ],
+        [
+          "standardResult.instances.2.excerpt",
+          "=",
+          "This article heading is illogical"
+        ]
+      ],
+      "rules": [
+        "y",
+        "secHeading"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          3
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "secHeading"
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Heading elements violate the logical level order in their sectioning containers"
+        ]
+      ],
+      "rules": [
+        "y",
+        "secHeading"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/textSem.json
+++ b/validation/tests/jobProperties/textSem.json
@@ -1,0 +1,152 @@
+{
+  "rule": "textSem",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/textSem/index.html",
+        "what": "page with semantically and nonsemantically varied text"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          4
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "textSem"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element is semantically vague"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "I"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.width",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "tag"
+        ],
+        [
+          "standardResult.instances.1.tagName",
+          "=",
+          "I"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "=",
+          "Never"
+        ],
+        [
+          "standardResult.instances.2.ordinalSeverity",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.2.tagName",
+          "=",
+          "B"
+        ],
+        [
+          "standardResult.instances.2.excerpt",
+          "=",
+          "accessible"
+        ],
+        [
+          "standardResult.instances.3.tagName",
+          "=",
+          "SMALL"
+        ],
+        [
+          "standardResult.instances.3.excerpt",
+          "=",
+          "This situation is rare and probably does not apply to you."
+        ]
+      ],
+      "rules": [
+        "y",
+        "textSem"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          4
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "textSem"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Semantically vague elements i, b, and/or small are used"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          4
+        ]
+      ],
+      "rules": [
+        "y",
+        "textSem"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Summary
- This PR adds five training Testaro rules and their implementations:
  - `altScheme`
  - `captionLoc`
  - `datalistRef`
  - `secHeading`
  - `textSem`

What changed
- New rule implementations: `testaro/altScheme.js`, `testaro/captionLoc.js`, `testaro/datalistRef.js`, `testaro/secHeading.js`, `testaro/textSem.js`.
- Validator job files copied to: `validation/tests/jobProperties/{altScheme,captionLoc,datalistRef,secHeading,textSem}.json`
- `VALIDATION_README.md` added with running instructions.
- Minor update to `tests/testaro.js` to move the five training rules from `futureRules` into `evalRules` so they are executed by the test harness.

Rationale
- These five rules are the “training” rules described in issue #34. They were implemented with normal consultation to ensure correct behavior and to learn the rule-creation process.
- The remaining five rules from the issue (the clean-room set) — `adbID`, `imageLink`, `legendLoc`, `optRoleSel`, and `phOnly` — are intentionally NOT included here; they will be implemented separately under clean‑room constraints.

Validation / How to run locally
1. Install dependencies:
   ```powershell
   npm install
   npx playwright install