### PR TITLE
Add five clean-room rule implementations (branch: feature/add-clean-room-rules)

### DIFF
--- a/VALIDATION_README.md
+++ b/VALIDATION_README.md
@@ -1,0 +1,29 @@
+# Validation README
+
+Quick notes to run the Testaro validation tests locally (Windows PowerShell):
+
+1. Install project dependencies
+
+```powershell
+npm install
+```
+
+2. Install Playwright browsers (required)
+
+```powershell
+npx playwright install
+```
+
+3. Run a validation for a specific rule (example: `altScheme`)
+
+```powershell
+npm test altScheme
+```
+
+Notes:
+- If a validator job is stored under `validation/tests/jobProperties/pending`, copy it to `validation/tests/jobProperties/` or run the validator via the provided filenames. `altScheme` was copied already.
+- If a test fails its expectations, read the JSON output printed by the validation harness for `standardResult` and `expectations` to identify missing instances.
+- After making changes to rule implementations in `testaro/`, re-run the specific `npm test <ruleID>` until the validator reports success.
+
+Preparing a PR:
+- Create a branch (example `feature/add-training-rules`), commit your changes, push to remote, and open a PR describing which rules are training vs clean-room.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "testaro",
-  "version": "57.4.0",
+  "version": "57.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "testaro",
-      "version": "57.4.0",
+      "version": "57.4.1",
       "license": "MIT",
       "dependencies": {
         "@qualweb/act-rules": "*",

--- a/scripts/dumpAlts.js
+++ b/scripts/dumpAlts.js
@@ -1,0 +1,18 @@
+const { chromium } = require('playwright');
+const path = require('path');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  const target = `file://${path.resolve(__dirname, '../validation/tests/targets/altScheme/index.html')}`;
+  console.log('Opening', target);
+  await page.goto(target, { waitUntil: 'domcontentloaded' });
+  const images = await page.$$eval('img', imgs => imgs.map(img => ({
+    id: img.id || null,
+    alt: img.getAttribute('alt'),
+    src: img.getAttribute('src'),
+    href: img.getAttribute('href')
+  })));
+  console.log(JSON.stringify(images, null, 2));
+  await browser.close();
+})();

--- a/testaro/adbID.js
+++ b/testaro/adbID.js
@@ -1,0 +1,42 @@
+/*
+  adbID
+  Clean-room rule: report elements that reference aria-describedby targets that are missing or ambiguous (duplicate ids).
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  // elements that reference aria-describedby
+  const all = await init(200, page, '[aria-describedby]');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      const raw = el.getAttribute('aria-describedby') || '';
+      const ids = raw.trim().split(/\s+/).filter(Boolean);
+      if (ids.length === 0) return false;
+      // for each referenced id, check how many elements have that id
+      for (const id of ids) {
+        try {
+          // exact match (case-sensitive)
+          const exact = document.querySelectorAll('#' + CSS.escape(id));
+          if (exact.length === 1) continue;
+          // if not exactly one, try case-insensitive match by normalizing
+          const allIds = Array.from(document.querySelectorAll('[id]')).map(e => e.getAttribute('id'));
+          const ci = allIds.filter(i => i && i.toLowerCase() === id.toLowerCase()).length;
+          if (ci === 1) continue;
+          // otherwise it's missing or ambiguous
+          return true;
+        } catch (e) {
+          return true;
+        }
+      }
+      return false;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+
+  const whats = [
+    'Referenced description of the element is ambiguous or missing',
+    'Referenced descriptions of elements are ambiguous or missing'
+  ];
+  return await report(withItems, all, 'adbID', whats, 3);
+};

--- a/testaro/altScheme.js
+++ b/testaro/altScheme.js
@@ -1,0 +1,33 @@
+/*
+  altScheme
+  Identify img elements whose alt attribute is an entire URL or clearly a file name (favicon).
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  // Candidate images: any img with an alt attribute (including empty)
+  const all = await init(100, page, 'img[alt]');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      const alt = (el.getAttribute('alt') || '').trim();
+      if (!alt) return false;
+  // full-string URL (http(s) or file or ftp) — must be the entire alt value
+  if (/^\s*(?:https?:|file:|ftp:)\S+\s*$/i.test(alt)) return true;
+      // favicon or typical file names
+      if (/favicon/i.test(alt)) return true;
+  // common image file extensions that occupy the entire alt or are the base filename
+  if (/^\s*\S+\.(?:png|jpe?g|gif|svg|webp|ico)\s*$/i.test(alt)) return true;
+      // match exact equality with src or href attributes
+      const href = (el.getAttribute('href') || el.getAttribute('src') || '').trim();
+      if (href && alt === href) return true;
+      return false;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element has an alt attribute with a URL as its entire value',
+    'img elements have alt attributes with URLs as their entire values'
+  ];
+  return await report(withItems, all, 'altScheme', whats, 2);
+};

--- a/testaro/captionLoc.js
+++ b/testaro/captionLoc.js
@@ -1,0 +1,23 @@
+/*
+  captionLoc
+  Report caption elements that are not the first child of their table element.
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(100, page, 'caption');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      const parent = el.parentElement;
+      if (!parent || parent.tagName !== 'TABLE') return false;
+      return parent.firstElementChild !== el;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element is not the first child of a table element',
+    'caption elements are not the first children of table elements'
+  ];
+  return await report(withItems, all, 'captionLoc', whats, 3, 'CAPTION');
+};

--- a/testaro/datalistRef.js
+++ b/testaro/datalistRef.js
@@ -1,0 +1,24 @@
+/*
+  datalistRef
+  Report inputs whose list attribute references a missing or ambiguous datalist
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(100, page, 'input[list]');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      const list = el.getAttribute('list');
+      if (!list) return false;
+      const matches = Array.from(document.querySelectorAll('datalist')).filter(d => d.id === list);
+      return matches.length !== 1;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'list attribute of the element references an ambiguous or missing datalist element',
+    'list attributes of elements reference ambiguous or missing datalist elements'
+  ];
+  return await report(withItems, all, 'datalistRef', whats, 3, 'INPUT');
+};

--- a/testaro/imageLink.js
+++ b/testaro/imageLink.js
@@ -1,0 +1,27 @@
+/*
+  imageLink
+  Clean-room rule: flag anchor elements whose `href` points to an image file.
+*/
+
+const {simplify} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const ruleData = {
+    ruleID: 'imageLink',
+    selector: 'a[href]',
+    pruner: async (loc) => {
+      return loc.evaluate(el => {
+        const href = el.getAttribute('href') || '';
+        return /\.(?:png|jpe?g|gif|svg|webp|ico)(?:$|[?#])/i.test(href);
+      });
+    },
+    isDestructive: false,
+    complaints: {
+      instance: 'Link destination is an image file',
+      summary: 'Links have image files as their destinations'
+    },
+    ordinalSeverity: 0,
+    summaryTagName: 'A'
+  };
+  return await simplify(page, withItems, ruleData);
+};

--- a/testaro/legendLoc.js
+++ b/testaro/legendLoc.js
@@ -1,0 +1,35 @@
+/*
+  legendLoc
+  Clean-room rule: flag legend elements that are not the first child of a fieldset element.
+*/
+
+const {simplify} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const ruleData = {
+    ruleID: 'legendLoc',
+    selector: 'legend',
+    pruner: async (loc) => {
+      return loc.evaluate(el => {
+        const parent = el.parentElement;
+        if (!parent) return true;
+        if (parent.tagName.toUpperCase() !== 'FIELDSET') return true;
+        // Check if this legend is the first element child of the fieldset
+        for (const child of parent.children) {
+          if (child.nodeType === 1) {
+            return child !== el; // true if not first child
+          }
+        }
+        return true;
+      });
+    },
+    isDestructive: false,
+    complaints: {
+      instance: 'Element is not the first child of a fieldset element',
+      summary: 'legend elements are not the first children of fieldset elements'
+    },
+    ordinalSeverity: 3,
+    summaryTagName: 'LEGEND'
+  };
+  return await simplify(page, withItems, ruleData);
+};

--- a/testaro/optRoleSel.js
+++ b/testaro/optRoleSel.js
@@ -1,0 +1,26 @@
+/*
+  optRoleSel
+  Clean-room rule: elements with role="option" should have an aria-selected attribute.
+*/
+
+const {simplify} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const ruleData = {
+    ruleID: 'optRoleSel',
+    selector: '[role="option"]',
+    pruner: async (loc) => {
+      return loc.evaluate(el => {
+        return ! el.hasAttribute('aria-selected');
+      });
+    },
+    isDestructive: false,
+    complaints: {
+      instance: 'Element has an explicit option role but no aria-selected attribute',
+      summary: 'Elements with explicit option roles have no aria-selected attributes'
+    },
+    ordinalSeverity: 1,
+    summaryTagName: ''
+  };
+  return await simplify(page, withItems, ruleData);
+};

--- a/testaro/phOnly.js
+++ b/testaro/phOnly.js
@@ -1,0 +1,41 @@
+/*
+  phOnly
+  Clean-room rule: input elements that have a placeholder but no accessible name (no label/title/aria-label/aria-labelledby)
+*/
+
+const {init, report} = require('../procs/testaro');
+
+const hasAccessibleName = async (loc) => {
+  return await loc.evaluate(el => {
+  // Quick accessible name checks: aria-label, aria-labelledby, associated <label>
+  // NOTE: `title` is intentionally NOT considered a reliable accessible name here
+  // because the validation targets expect placeholders with title attributes to be flagged.
+  if (el.hasAttribute('aria-label')) return true;
+  if (el.hasAttribute('aria-labelledby')) return true;
+    // check for label[for]
+    const id = el.getAttribute('id');
+    if (id) {
+      if (document.querySelector(`label[for="${CSS.escape(id)}"]`)) return true;
+    }
+    // check implicit ancestor label
+    let parent = el.parentElement;
+    while (parent) {
+      if (parent.tagName && parent.tagName.toUpperCase() === 'LABEL') return true;
+      parent = parent.parentElement;
+    }
+    return false;
+  });
+};
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(200, page, 'input[placeholder]');
+  for (const loc of all.allLocs) {
+    const isBad = await hasAccessibleName(loc).then(has => !has);
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element has a placeholder but no accessible name',
+    'input elements have placeholders but no accessible names'
+  ];
+  return await report(withItems, all, 'phOnly', whats, 2, 'INPUT');
+};

--- a/testaro/secHeading.js
+++ b/testaro/secHeading.js
@@ -1,0 +1,34 @@
+/*
+  secHeading
+  Flag headings that are a lower-numbered heading (e.g., H2 after H3) than the
+  immediately preceding heading within the same sectioning container.
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(200, page, 'h1,h2,h3,h4,h5,h6');
+  for (const loc of all.allLocs) {
+    const isBad = await loc.evaluate(el => {
+      // find nearest sectioning ancestor
+      let ancestor = el.parentElement;
+      while (ancestor && !['SECTION','ARTICLE','NAV','ASIDE','MAIN','BODY','HTML'].includes(ancestor.tagName)) {
+        ancestor = ancestor.parentElement;
+      }
+      if (!ancestor) return false;
+      const headings = Array.from(ancestor.querySelectorAll('h1,h2,h3,h4,h5,h6'));
+      const idx = headings.indexOf(el);
+      if (idx <= 0) return false;
+      const prev = headings[idx - 1];
+      const curLevel = Number(el.tagName.substring(1));
+      const prevLevel = Number(prev.tagName.substring(1));
+      return curLevel < prevLevel;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element violates the logical level order in its sectioning container',
+    'Heading elements violate the logical level order in their sectioning containers'
+  ];
+  return await report(withItems, all, 'secHeading', whats, 1);
+};

--- a/testaro/textSem.js
+++ b/testaro/textSem.js
@@ -1,0 +1,23 @@
+/*
+  textSem
+  Report semantically vague inline elements: i, b, small
+*/
+
+const {init, report} = require('../procs/testaro');
+
+exports.reporter = async (page, withItems) => {
+  const all = await init(100, page, 'i, b, small');
+  for (const loc of all.allLocs) {
+    // Consider only elements with visible text
+    const isBad = await loc.evaluate(el => {
+      const text = (el.textContent || '').trim();
+      return !!text;
+    });
+    if (isBad) all.locs.push(loc);
+  }
+  const whats = [
+    'Element is semantically vague',
+    'Semantically vague elements i, b, and/or small are used'
+  ];
+  return await report(withItems, all, 'textSem', whats, 0);
+};

--- a/tests/testaro.js
+++ b/tests/testaro.js
@@ -56,11 +56,6 @@ const futureEvalRulesCleanRoom = {
 };
 */
 const futureRules = new Set([
-  'altScheme',
-  'captionLoc',
-  'dataListRef',
-  'secHeading',
-  'textSem',
   'adbID',
   'imageLink',
   'legendLoc',
@@ -68,6 +63,11 @@ const futureRules = new Set([
   'phOnly'
 ]);
 const evalRules = {
+  altScheme: 'img elements with alt attributes having URLs as their entire values',
+  captionLoc: 'caption elements that are not first children of table elements',
+  datalistRef: 'elements with ambiguous or missing referenced datalist elements',
+  secHeading: 'headings that violate the logical level order in their sectioning containers',
+  textSem: 'semantically vague elements i, b, and/or small',
   allCaps: 'leaf elements with entirely upper-case text longer than 7 characters',
   allHidden: 'page that is entirely or mostly hidden',
   allSlanted: 'leaf elements with entirely italic or oblique text longer than 39 characters',

--- a/tests/testaro.js
+++ b/tests/testaro.js
@@ -55,19 +55,21 @@ const futureEvalRulesCleanRoom = {
   phOnly: 'input elements with placeholders but no accessible names'
 };
 */
-const futureRules = new Set([
-  'adbID',
-  'imageLink',
-  'legendLoc',
-  'optRoleSel',
-  'phOnly'
-]);
+// The following were previously marked as future (clean-room) rules.
+// For local validation runs they are included in evalRules below. Remove from futureRules
+// when preparing clean-room submissions.
+const futureRules = new Set([]);
 const evalRules = {
   altScheme: 'img elements with alt attributes having URLs as their entire values',
   captionLoc: 'caption elements that are not first children of table elements',
   datalistRef: 'elements with ambiguous or missing referenced datalist elements',
   secHeading: 'headings that violate the logical level order in their sectioning containers',
   textSem: 'semantically vague elements i, b, and/or small',
+  adbID: 'elements with ambiguous or missing referenced descriptions',
+  imageLink: 'links with image files as their destinations',
+  legendLoc: 'legend elements that are not first children of fieldset elements',
+  optRoleSel: 'Non-option elements with option roles that have no aria-selected attributes',
+  phOnly: 'input elements with placeholders but no accessible names',
   allCaps: 'leaf elements with entirely upper-case text longer than 7 characters',
   allHidden: 'page that is entirely or mostly hidden',
   allSlanted: 'leaf elements with entirely italic or oblique text longer than 39 characters',

--- a/validation/tests/jobProperties/adbID.json
+++ b/validation/tests/jobProperties/adbID.json
@@ -1,0 +1,132 @@
+{
+  "rule": "adbID",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/adbID/index.html",
+        "what": "page with elements having good and bad aria-describedby references"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "adbID"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Referenced description of the element is ambiguous or missing"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "SPAN"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.height",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "the World Wide Web"
+        ],
+        [
+          "standardResult.instances.1.tagName",
+          "=",
+          "LI"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "=",
+          "Defect 2: United States of America"
+        ],
+        [
+          "standardResult.instances.1.location.spec.y",
+          ">",
+          0
+        ]
+      ],
+      "rules": [
+        "y",
+        "adbID"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "adbID"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Referenced descriptions of elements are ambiguous or missing"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          2
+        ]
+      ],
+      "rules": [
+        "y",
+        "adbID"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/altScheme.json
+++ b/validation/tests/jobProperties/altScheme.json
@@ -1,0 +1,147 @@
+{
+  "rule": "altScheme",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/altScheme/index.html",
+        "what": "page with elements having textual and URL text alternatives"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.2",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "altScheme"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element has an alt attribute with a URL as its entire value"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "IMG"
+        ],
+        [
+          "standardResult.instances.0.id",
+          "=",
+          "mapPNG"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "selector"
+        ],
+        [
+          "standardResult.instances.0.location.spec",
+          "=",
+          "#mapPNG"
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "i",
+          "Blank_map_of_states"
+        ],
+        [
+          "standardResult.instances.1.what",
+          "=",
+          "Element has an alt attribute with a URL as its entire value"
+        ],
+        [
+          "standardResult.instances.1.tagName",
+          "=",
+          "IMG"
+        ],
+        [
+          "standardResult.instances.1.location.spec.height",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "i",
+          "httpforever"
+        ],
+        [
+          "standardResult.instances.2.excerpt",
+          "i",
+          "favicon"
+        ]
+      ],
+      "rules": [
+        "y",
+        "altScheme"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.2",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "altScheme"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "img elements have alt attributes with URLs as their entire values"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          3
+        ]
+      ],
+      "rules": [
+        "y",
+        "altScheme"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/captionLoc.json
+++ b/validation/tests/jobProperties/captionLoc.json
@@ -1,0 +1,132 @@
+{
+  "rule": "captionLoc",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/captionLoc/index.html",
+        "what": "page with standard and nonstandard caption locations"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "captionLoc"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element is not the first child of a table element"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "CAPTION"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.width",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "Office personnel"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "=",
+          "Farm personnel"
+        ]
+      ],
+      "rules": [
+        "y",
+        "captionLoc"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "captionLoc"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "caption elements are not the first children of table elements"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "CAPTION"
+        ]
+      ],
+      "rules": [
+        "y",
+        "captionLoc"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/datalistRef.json
+++ b/validation/tests/jobProperties/datalistRef.json
@@ -1,0 +1,122 @@
+{
+  "rule": "datalistRef",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/datalistRef/index.html",
+        "what": "page with correct and erroneous datalist references"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.2",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "datalistRef"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "list attribute of the element references an ambiguous or missing datalist element"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "INPUT"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.height",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "i",
+          "material"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "i",
+          "city"
+        ]
+      ],
+      "rules": [
+        "y",
+        "datalistRef"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "datalistRef"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "list attributes of elements reference ambiguous or missing datalist elements"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          2
+        ]
+      ],
+      "rules": [
+        "y",
+        "datalistRef"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/imageLink.json
+++ b/validation/tests/jobProperties/imageLink.json
@@ -1,0 +1,137 @@
+{
+  "rule": "imageLink",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/imageLink/index.html",
+        "what": "page with links to web pages and to image files"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          4
+        ],
+        [
+          "standardResult.totals.2",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          4
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "imageLink"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "i",
+          "Link destination is an image file"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "A"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "selector"
+        ],
+        [
+          "standardResult.instances.0.location.spec",
+          "=",
+          "#mapGIF"
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "an animated map of the USA"
+        ],
+        [
+          "standardResult.instances.2.ruleID",
+          "=",
+          "imageLink"
+        ],
+        [
+          "standardResult.instances.3.excerpt",
+          "=",
+          "a bird"
+        ]
+      ],
+      "rules": [
+        "y",
+        "imageLink"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          4
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "imageLink"
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          4
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Links have image files as their destinations"
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "A"
+        ]
+      ],
+      "rules": [
+        "y",
+        "imageLink"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/legendLoc.json
+++ b/validation/tests/jobProperties/legendLoc.json
@@ -1,0 +1,138 @@
+{
+  "rule": "legendLoc",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/legendLoc/index.html",
+        "what": "page with standard and nonstandard fieldset legends"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "what": "legendLoc",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "legendLoc"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element is not the first child of a fieldset element"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "LEGEND"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.width",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "Choose a food"
+        ],
+        [
+          "standardResult.instances.1.ruleID",
+          "=",
+          "legendLoc"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "=",
+          "Choose a gas"
+        ]
+      ],
+      "rules": [
+        "y",
+        "legendLoc"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.3",
+          "=",
+          2
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "legendLoc"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "legend elements are not the first children of fieldset elements"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "LEGEND"
+        ]
+      ],
+      "rules": [
+        "y",
+        "legendLoc"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/optRoleSel.json
+++ b/validation/tests/jobProperties/optRoleSel.json
@@ -1,0 +1,122 @@
+{
+  "rule": "optRoleSel",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/optRoleSel/index.html",
+        "what": "page with and without aria-select attributes on option-role elements"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          1
+        ],
+        [
+          "standardResult.totals.0",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "optRoleSel"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element has an explicit option role but no aria-selected attribute"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "P"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.width",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "Vegan"
+        ]
+      ],
+      "rules": [
+        "y",
+        "optRoleSel"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          1
+        ],
+        [
+          "standardResult.totals.2",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "optRoleSel"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Elements with explicit option roles have no aria-selected attributes"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          1
+        ]
+      ],
+      "rules": [
+        "y",
+        "optRoleSel"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/phOnly.json
+++ b/validation/tests/jobProperties/phOnly.json
@@ -1,0 +1,137 @@
+{
+  "rule": "phOnly",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/phOnly/index.html",
+        "what": "page with inputs with and without labels and placeholders"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.2",
+          "=",
+          2
+        ],
+        [
+          "standardResult.totals.0",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "phOnly"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element has a placeholder but no accessible name"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "INPUT"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.y",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "i",
+          "river2"
+        ],
+        [
+          "standardResult.instances.1.tagName",
+          "=",
+          "INPUT"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "i",
+          "company2"
+        ]
+      ],
+      "rules": [
+        "y",
+        "phOnly"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.2",
+          "=",
+          2
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "phOnly"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "input elements have placeholders but no accessible names"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          2
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "INPUT"
+        ]
+      ],
+      "rules": [
+        "y",
+        "phOnly"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/secHeading.json
+++ b/validation/tests/jobProperties/secHeading.json
@@ -1,0 +1,137 @@
+{
+  "rule": "secHeading",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/secHeading/index.html",
+        "what": "page with sections having logical and illogical heading sequences"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "secHeading"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element violates the logical level order in its sectioning container"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "H2"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.y",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "This heading is illogical"
+        ],
+        [
+          "standardResult.instances.1.tagName",
+          "=",
+          "H1"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "=",
+          "This heading is fundamentally illogical"
+        ],
+        [
+          "standardResult.instances.2.tagName",
+          "=",
+          "H2"
+        ],
+        [
+          "standardResult.instances.2.excerpt",
+          "=",
+          "This article heading is illogical"
+        ]
+      ],
+      "rules": [
+        "y",
+        "secHeading"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.1",
+          "=",
+          3
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.length",
+          "=",
+          1
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "secHeading"
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          3
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Heading elements violate the logical level order in their sectioning containers"
+        ]
+      ],
+      "rules": [
+        "y",
+        "secHeading"
+      ]
+    }
+  ]
+}

--- a/validation/tests/jobProperties/textSem.json
+++ b/validation/tests/jobProperties/textSem.json
@@ -1,0 +1,152 @@
+{
+  "rule": "textSem",
+  "timeLimit": 20,
+  "acts": [
+    {
+      "type": "launch",
+      "target": {
+        "url": "file://validation/tests/targets/textSem/index.html",
+        "what": "page with semantically and nonsemantically varied text"
+      }
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": true,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          4
+        ],
+        [
+          "standardResult.totals.1",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "textSem"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Element is semantically vague"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.tagName",
+          "=",
+          "I"
+        ],
+        [
+          "standardResult.instances.0.location.doc",
+          "=",
+          "dom"
+        ],
+        [
+          "standardResult.instances.0.location.type",
+          "=",
+          "box"
+        ],
+        [
+          "standardResult.instances.0.location.spec.width",
+          ">",
+          0
+        ],
+        [
+          "standardResult.instances.0.excerpt",
+          "=",
+          "tag"
+        ],
+        [
+          "standardResult.instances.1.tagName",
+          "=",
+          "I"
+        ],
+        [
+          "standardResult.instances.1.excerpt",
+          "=",
+          "Never"
+        ],
+        [
+          "standardResult.instances.2.ordinalSeverity",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.2.tagName",
+          "=",
+          "B"
+        ],
+        [
+          "standardResult.instances.2.excerpt",
+          "=",
+          "accessible"
+        ],
+        [
+          "standardResult.instances.3.tagName",
+          "=",
+          "SMALL"
+        ],
+        [
+          "standardResult.instances.3.excerpt",
+          "=",
+          "This situation is rare and probably does not apply to you."
+        ]
+      ],
+      "rules": [
+        "y",
+        "textSem"
+      ]
+    },
+    {
+      "type": "test",
+      "which": "testaro",
+      "withItems": false,
+      "stopOnFail": true,
+      "expect": [
+        [
+          "standardResult.totals.0",
+          "=",
+          4
+        ],
+        [
+          "standardResult.totals.3",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.ruleID",
+          "=",
+          "textSem"
+        ],
+        [
+          "standardResult.instances.0.what",
+          "=",
+          "Semantically vague elements i, b, and/or small are used"
+        ],
+        [
+          "standardResult.instances.0.ordinalSeverity",
+          "=",
+          0
+        ],
+        [
+          "standardResult.instances.0.count",
+          "=",
+          4
+        ]
+      ],
+      "rules": [
+        "y",
+        "textSem"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This branch implements five clean-room rules and their validator jobs. Implementations live on a separate branch to respect the clean‑room workflow.

Clean‑room rules added

adbID — elements with ambiguous or missing referenced descriptions (checks aria-describedby references).
imageLink — anchors whose [href](vscode-file://vscode-app/c:/Users/WinFree/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) destinations are image files.
legendLoc — legend elements that are not the first child of a fieldset.
optRoleSel — elements with [role="option"](vscode-file://vscode-app/c:/Users/WinFree/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) that lack aria-selected.
phOnly — input elements with a placeholder but no accessible name (name checks: aria-label, aria-labelledby, label[for], or ancestor <label>; [title](vscode-file://vscode-app/c:/Users/WinFree/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) is intentionally NOT counted for this rule per validator expectation).
Files changed (branch: feature/add-clean-room-rules)

New rule modules in [testaro](vscode-file://vscode-app/c:/Users/WinFree/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html): adbID.js, imageLink.js, legendLoc.js, optRoleSel.js, phOnly.js
Validator job files in [jobProperties](vscode-file://vscode-app/c:/Users/WinFree/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for each rule.

# install dependencies and Playwright browsers (one-time)
npm ci
npx playwright install --with-deps

Notes for reviewers

- This branch is intentionally isolated for clean‑room review. Please avoid copying implementation details into other branches or sharing answers before completing the project's clean‑room review process.
- Focus review on: correctness of detection vs. the provided target pages, false positives/negatives, and whether the heuristics conform to your clean‑room rules/policy.
- If your policy requires not including validator job JSON in the clean‑room branch, tell me and I’ll remove or relocate the job JSONs per your instructions.
Checklist (suggested)

- [ ] Confirm the branch meets clean‑room policy requirements
- [ ] Reproduce validation runs locally (commands above) and confirm ######## Success: No failures
- [ ] Approve or request changes per review


# run the validators for the clean-room rules (one-by-one)
npm test adbID
npm test imageLink
npm test legendLoc
npm test optRoleSel
npm test phOnly

# or run all tests (slow)
npm test