### PR TITLE
add license heading to README per mgifford pull request

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,6 +965,8 @@ As of 12 February 2024, upon the transfer of the repository ownership to CVS Hea
 
 “Testaro” means “collection of tests” in Esperanto.
 
+## License
+
 /*
   © 2021–2025 CVS Health and/or one of its affiliates. All rights reserved.
 


### PR DESCRIPTION
A License heading is added to the README file.

mgifford proposed this in a pull request in July 2024 but did not execute the contributor license agreement required by CVS Health, so that pull request could not be approved. This pull request is identical to that.